### PR TITLE
[Discussion] Adding VS Live Share

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
 - [Markdown+Math](https://marketplace.visualstudio.com/items?itemName=goessner.mdmath) - Mdmath allows to use Visual Studio Code as a markdown editor capable of typesetting and rendering TeX math. In fact it now reuses the built in markdown viewer. KaTeX works inside as a fast math renderer.
 - [Markdown Preview Enhanced](https://marketplace.visualstudio.com/items?itemName=shd101wyy.markdown-preview-enhanced) - Markdown Preview Enhanced is an extension that provides you with many useful functionalities such as automatic scroll sync, math typesetting, mermaid, PlantUML, pandoc, PDF export, code chunk, presentation writer, etc.
 - [Markdown TOC](https://marketplace.visualstudio.com/items?itemName=AlanWalk.markdown-toc) - Generate TOC (table of contents) of headlines from parsed markdown file.
+- [VS Live Share](https://marketplace.visualstudio.com/items?itemName=MS-vsliveshare.vsliveshare) - Adds collaborative editing support directly into VS Code, which makes it possible to work on Markdown files with others in real-time!
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
         "goessner.mdmath",
         "shd101wyy.markdown-preview-enhanced",
         "yzane.markdown-pdf",
-        "AlanWalk.markdown-toc"
+        "AlanWalk.markdown-toc",
+        "MS-vsliveshare.vsliveshare"
     ]
 }


### PR DESCRIPTION
This PR proposes adding [Visual Studio Live Share](aka.ms/vsls) to this extension pack, since it's optimized for Markdown editing, and is being used by a lot of devs/writers to collaboratively edit Markdown files in real-time.

// CC @bat67 