### PR TITLE
Include the missing :emojisense: VS Code extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
         "AlanWalk.markdown-toc",
         "darkriszty.markdown-table-prettify",
         "bierner.markdown-emoji",
-	"bierner.emojisense",
+        "bierner.emojisense",
         "ionutvmi.path-autocomplete",
         "bierner.markdown-checkbox",
         "bierner.markdown-preview-github-styles",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
         "AlanWalk.markdown-toc",
         "darkriszty.markdown-table-prettify",
         "bierner.markdown-emoji",
+	"bierner.emojisense",
         "ionutvmi.path-autocomplete",
         "bierner.markdown-checkbox",
         "bierner.markdown-preview-github-styles",


### PR DESCRIPTION
This extension is listed in the markdown-extension-pack, but is missing from the list of included extensions.