### PR TITLE
add markdown-preview extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,24 +2,32 @@
 
 All notable changes to the "markdown-extension-pack" extension pack will be documented in this file.
 
+## 0.7.1
+
+- Add [Markdown Preview](https://marketplace.visualstudio.com/items?itemName=ezrafree.markdown-preview), thanks for [ezrafree's PR](https://github.com/bat67/markdown-extension-pack/pull/8)
+
 ## 0.7.0
+
 - Add [Medium to Markdown](https://marketplace.visualstudio.com/items?itemName=moshfeu.vscode-medium-to-markdown), thanks for [moshfeu's PR](https://github.com/bat67/markdown-extension-pack/pull/6)
 - Fix unincluded [:emojisense:](https://marketplace.visualstudio.com/items?itemName=bierner.emojisense), thanks for [starriddle's issue](https://github.com/bat67/markdown-extension-pack/issues/5) and [RobertBernstein's PR](https://github.com/bat67/markdown-extension-pack/pull/7)
 
 ## 0.6.0
+
 - Add [Markdown Shortcuts](https://marketplace.visualstudio.com/items?itemName=mdickin.markdown-shortcuts) and [Excel to Markdown table](https://marketplace.visualstudio.com/items?itemName=csholmq.excel-to-markdown-table), thanks for doggy8088's [issue1](https://github.com/bat67/markdown-extension-pack/issues/4) and [issue2](https://github.com/bat67/markdown-extension-pack/issues/3)
 
 ## 0.5.0
+
 - Add [Markdown Checkboxes](https://marketplace.visualstudio.com/items?itemName=bierner.markdown-checkbox), [Markdown Preview Github Styling](https://marketplace.visualstudio.com/items?itemName=bierner.markdown-preview-github-styles), [:emojisense:](https://marketplace.visualstudio.com/items?itemName=bierner.emojisense), and [Markdown Paste](https://marketplace.visualstudio.com/items?itemName=telesoho.vscode-markdown-paste-image).
 - Delete [VS Live Share](https://marketplace.visualstudio.com/items?itemName=MS-vsliveshare.vsliveshare)
 
 ## 0.4.0
+
 - Add [Path Autocomplete](https://marketplace.visualstudio.com/items?itemName=ionutvmi.path-autocomplete)
 
 ## 0.3.0
+
 - Add [VS Live Share](https://marketplace.visualstudio.com/items?itemName=MS-vsliveshare.vsliveshare), thanks for [lostintangent's PR](https://github.com/bat67/markdown-extension-pack/pull/2)
 - Add [Markdown Table Prettifier](https://marketplace.visualstudio.com/items?itemName=darkriszty.markdown-table-prettify) and [Markdown Emoji](https://marketplace.visualstudio.com/items?itemName=bierner.markdown-emoji), thanks for [danilofreire' issue](https://github.com/bat67/markdown-extension-pack/issues/1)
-
 
 ## 0.1.2
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@
 - [Markdown Shortcuts](https://marketplace.visualstudio.com/items?itemName=mdickin.markdown-shortcuts) - Handy shortcuts for editing Markdown (.md, .markdown) files. You can also use markdown formats in any other file.
 - [Excel to Markdown table](https://marketplace.visualstudio.com/items?itemName=csholmq.excel-to-markdown-table) - This VSCode extension converts Excel data to Markdown table format. Available through command Excel to Markdown table and keyboard shortcut Shift+Alt+V.
 - [Medium to Markdown](https://marketplace.visualstudio.com/items?itemName=moshfeu.vscode-medium-to-markdown) - Use Medium to Markdown to fetch and convert your Medium posts into local markdown files.
+- [Markdown Preview](https://marketplace.visualstudio.com/items?itemName=ezrafree.markdown-preview) - Add copy button to fenced code blocks, adjust built-in VS Code preview styling.
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "markdown-extension-pack",
     "displayName": "Markdown Extension Pack",
     "description": "Popular Visual Studio Code extensions for Markdown",
-    "version": "0.7.0",
+    "version": "0.7.1",
     "publisher": "bat67",
     "icon": "icon.jpg",
     "engines": {
@@ -10,30 +10,30 @@
     },
     "galleryBanner": {
         "color": "#333333",
-		"theme": "dark"
+        "theme": "dark"
     },
     "keywords": [
         "markdown",
-		"markdownlint",
+        "markdownlint",
         "LaTex",
         "linter",
-		"extension pack"
-	],
+        "extension pack"
+    ],
     "categories": [
         "Extension Packs"
     ],
     "license": "SEE LICENSE IN LICENSE.md",
     "repository": {
-		"type": "git",
-		"url": "https://github.com/bat67/markdown-extension-pack"
-	},
-	"homepage": "https://github.com/bat67/markdown-extension-pack",
-	"bugs": {
+        "type": "git",
+        "url": "https://github.com/bat67/markdown-extension-pack"
+    },
+    "homepage": "https://github.com/bat67/markdown-extension-pack",
+    "bugs": {
         "url": "https://github.com/bat67/markdown-extension-pack/issues"
     },
-    "extensionDependencies": [ 
+    "extensionDependencies": [
         "yzhang.markdown-all-in-one",
-        "DavidAnson.vscode-markdownlint", 
+        "DavidAnson.vscode-markdownlint",
         "goessner.mdmath",
         "shd101wyy.markdown-preview-enhanced",
         "yzane.markdown-pdf",
@@ -47,6 +47,7 @@
         "telesoho.vscode-markdown-paste-image",
         "mdickin.markdown-shortcuts",
         "csholmq.excel-to-markdown-table",
-        "moshfeu.vscode-medium-to-markdown"
+        "moshfeu.vscode-medium-to-markdown",
+        "ezrafree.vscode-markdown-preview"
     ]
 }


### PR DESCRIPTION
This PR adds the `ezrafree.markdown-preview` extension.